### PR TITLE
fix: fix startup with Redis DB enabled

### DIFF
--- a/dbaas-client-java/dbaas-client-redis-starter/src/main/java/org/qubership/cloud/dbaas/client/redis/configuration/DbaasRedisConfiguration.java
+++ b/dbaas-client-java/dbaas-client-redis-starter/src/main/java/org/qubership/cloud/dbaas/client/redis/configuration/DbaasRedisConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @EnableDbaasDefault
 @Configuration
@@ -26,6 +27,7 @@ public class DbaasRedisConfiguration {
     }
 
     @Bean
+    @Primary
     @ConfigurationProperties("dbaas.redis")
     public RedisProperties redisProperties() {
         return new RedisProperties();


### PR DESCRIPTION
Make RedisProperties bean as Primary to not conflict with the one provided by Spring